### PR TITLE
Rename dltHub Basic tier to dltHub Pro in docs

### DIFF
--- a/docs/website/docs/hub/intro.md
+++ b/docs/website/docs/hub/intro.md
@@ -64,7 +64,7 @@ dltHub embraces the dlt library, not replaces it:
 dltHub extends the dlt developer experience with new [local workspace layout](workspace/init.md), [configuration profiles](core-concepts/profiles-dlthub.md), [additional CLI commands](command-line-interface.md), workspace dashboard, [MCP server](features/mcp-server.md) and more.
 Those developer experience improvements belong to **dltHub Free tier** and are distributed side by side with the `dlt` under [Apache 2.0 license](https://github.com/dlt-hub/dlt?tab=Apache-2.0-1-ov-file#readme). You can use **dltHub Free tier** right away - like you use regular `dlt`.
 
-All features that require a license are part of dltHub paid tiers (i.e. Basic tier) and are clearly marked as such in this documentation. Those features are shipped via `dlthub` Python package (available on [PyPI](https://pypi.org/project/dlthub/)) which is not open source and can be used with a valid license.
+All features that require a license are part of dltHub paid tiers (i.e. Pro tier) and are clearly marked as such in this documentation. Those features are shipped via `dlthub` Python package (available on [PyPI](https://pypi.org/project/dlthub/)) which is not open source and can be used with a valid license.
 
 ## dltHub products
 dltHub consists of three main products. You can use them together or compose them based on your needs.
@@ -105,7 +105,7 @@ Most features support a self-guided trial right after install, check the [instal
 
 | Tier                  | Best for                                                                                        | Runtime                        | Typical use case                                                              | Notes                                           | Availability    |
 | --------------------- |-------------------------------------------------------------------------------------------------| ------------------------------ |-------------------------------------------------------------------------------|-------------------------------------------------|-----------------|
-| **dltHub Basic**      | Solo developers or small teams owning a **single pipeline + dataset + reports** end-to-end      | Managed dltHub Runtime         | Set up a pipeline quickly, add tests and transformations, share a simple app  | Optimized for velocity with minimal setup       | Private preview |
+| **dltHub Pro**        | Solo developers or small teams owning a **single pipeline + dataset + reports** end-to-end      | Managed dltHub Runtime         | Set up a pipeline quickly, add tests and transformations, share a simple app  | Optimized for velocity with minimal setup       | Private preview |
 | **dltHub Scale**      | Data teams building **composable data platforms** with governance and collaboration             | Managed dltHub Runtime         | Multiple pipelines, shared assets, team workflows, observability              | Team features and extended governance           | Alpha           |
 | **dltHub Enterprise** | Organizations needing **enterprise control** or **self-managed runtime**                        | Managed or self-hosted Runtime | On-prem/VPC deployments, custom licensing, advanced security                  | Enterprise features and deployment flexibility  | In development  |
 
@@ -117,7 +117,7 @@ Most features support a self-guided trial right after install, check the [instal
 * Organizations that prefer managed operations but need open formats and portability.
 
 :::note
-* You can start on Basic and upgrade to Scale or Enterprise later, no code rewrites.
+* You can start on Pro and upgrade to Scale or Enterprise later, no code rewrites.
 * We favor open formats and portable storage (e.g., Iceberg), whether you choose our managed lakehouse or bring your own.
 * For exact features and pricing, check the site; this section is meant to help you choose a sensible starting point.
 :::


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Renames all instances of "dltHub Basic" to "dltHub Pro" in the documentation Hub introduction page (`docs/website/docs/hub/intro.md`).

Three changes were made:
- Tier table row: **dltHub Basic** → **dltHub Pro**
- Inline reference: "i.e. Basic tier" → "i.e. Pro tier"
- Upgrade note: "start on Basic" → "start on Pro"

### Related Issues

- Reported in #solutions-engineering Slack channel

### Additional Context

The dltHub Basic tier has been renamed to dltHub Pro. This PR updates the documentation to reflect that change.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dlthubinc.slack.com/archives/C069UBTBAUU/p1774618069672239?thread_ts=1774618069.672239&cid=C069UBTBAUU)

<div><a href="https://cursor.com/agents/bc-6d8a76bc-8368-577c-bff5-f2eb5fc8bfee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d8a76bc-8368-577c-bff5-f2eb5fc8bfee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated licensing and tiering documentation to reflect the Pro tier as the primary offering for solo and small-team users
  * Revised tier table and getting started instructions to align tier naming with current offerings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->