### PR TITLE
chore: add trunk linter configuration

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.vale.ini
+++ b/.trunk/configs/.vale.ini
@@ -1,0 +1,5 @@
+[formats]
+markdoc = md
+
+[*.md]
+BasedOnStyles = Vale

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,31 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.25.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.7.6
+      uri: https://github.com/trunk-io/plugins
+
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - vale@3.14.1
+
+  ignore:
+    - linters: [ALL]
+      paths:
+        - "**"
+        - "!docs/**"
+
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-cache-prune
+    - trunk-upgrade-available
+    - trunk-check-pre-push
+  disabled:
+    - trunk-fmt-pre-commit


### PR DESCRIPTION
Adds Trunk linter configuration with Vale integration.

This adds:
- `.trunk/trunk.yaml` — Trunk configuration with Vale enabled
- `.trunk/configs/.vale.ini` — Vale linter configuration  
- `.trunk/.gitignore` — Gitignore for Trunk artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured linting and formatting tools for documentation and Markdown files.
  * Added project management configuration for development workflows.
  * Added patterns to ignore development-related files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->